### PR TITLE
Make iptables installation conditional on fallback attribute.

### DIFF
--- a/recipes/disable.rb
+++ b/recipes/disable.rb
@@ -3,7 +3,7 @@
 # Recipe:: disable
 #
 
-package 'iptables-services'
+package 'iptables-services' if node['firewalld']['iptables_fallback']
 
 service 'firewalld' do
   action [:disable, :stop]


### PR DESCRIPTION
Only install `iptables` if the `iptables_fallback` attributes is set to true.
